### PR TITLE
add optind parameter to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,15 +135,17 @@ coverage.  There are no known bugs.
 API
 ---
 
-### `new getopt.BasicParser(optstring, argv)`
+### `new getopt.BasicParser(optstring, argv[, optind])`
 
 Instantiates a new object for parsing the specified arguments using the
 specified option string.  This interface is closest to the traditional getopt()
 C function.  Callers first instantiate a BasicParser and then invoke the
 getopt() method to iterate the options as they would in C.  (This interface
-allows the same option to be specified multiple times.)  The first two arguments
-in "argv" are ignored, since they generally denote the path to the node
-executable and the script being run, so options start with the third element.
+allows the same option to be specified multiple times.)  The optional 3rd
+argument to the constructor `optind` is the number of arguments from `argv` to
+skip.  By default `optind` is set to `2`, so the first two arguments in `argv`
+are ignored, since they generally denote the path to the node executable and
+the script being run.
 
 The option string consists of an optional leading ":" (see below) followed by a
 sequence of option-specifiers.  Each option-specifier consists of a single

--- a/lib/getopt.js
+++ b/lib/getopt.js
@@ -34,7 +34,7 @@ function goError(msg)
  * documentation for this object and its public methods is contained in
  * the included README.md.
  */
-function goBasicParser(optstring, argv)
+function goBasicParser(optstring, argv, optind)
 {
 	var ii;
 
@@ -46,7 +46,7 @@ function goBasicParser(optstring, argv)
 	this.gop_argv = new Array(argv.length);
 	this.gop_options = {};
 	this.gop_aliases = {};
-	this.gop_optind = 2;
+	this.gop_optind = optind !== undefined ? optind : 2;
 	this.gop_subind = 0;
 
 	for (ii = 0; ii < argv.length; ii++) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
 	"engines": {
 		"node": "*"
 	},
+	"scripts": {
+		"test": "for f in tests/*.js; do echo \"$f\"; node \"$f\" || exit 1; done"
+	},
 	"main": "./lib/getopt",
 	"repository": {
 		"type": "git",

--- a/tests/test-getopt.js
+++ b/tests/test-getopt.js
@@ -1,9 +1,6 @@
 /*
  * Tests getopt() itself.
  */
-var mod_path = require('path');
-
-var mod_sys = require('sys');
 var mod_getopt = require('..');
 var mod_assert = require('assert');
 
@@ -68,6 +65,21 @@ var test_cases = [ {
 	result: [
 	   { option: '\u1000', optarg: 100 },
 	]
+}, {
+	optstr: 'h',
+	argv: ['-h'],
+	result: [
+	   { option: 'h' },
+	],
+        optind: 0
+}, {
+	optstr: 'hv',
+	argv: ['foo', '-h', '-v' ],
+	result: [
+	   { option: 'h' },
+	   { option: 'v' },
+	],
+        optind: 1
 }];
 
 var parser, ii, arg, result;
@@ -75,7 +87,7 @@ for (ii = 0; ii < test_cases.length; ii++) {
 	console.log('test case %s: "%s" with argv = "%s"', ii + 1,
 	    test_cases[ii].optstr, test_cases[ii].argv);
 	parser = new mod_getopt.BasicParser(test_cases[ii].optstr,
-	    test_cases[ii].argv);
+	    test_cases[ii].argv, test_cases[ii].optind);
 	console.log(parser.gop_tokens);
 
 	result = [];


### PR DESCRIPTION
This is useful for allowing `getopt` to be used for subcommands... ie.

``` js
var argv = ['node', 'script.js', 'install', '-v', 'foobar']
var args = argv.slice(2);
var cmd = args.shift();

console.log('command: %s', cmd);
console.log('args: %s', args);

var parser = new getopt.BasicParser('v', args, 0);
```

output

```
command: install
args: -v,foobar
```